### PR TITLE
Bugfix/gfortran10 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,11 @@ ecbuild_add_library( TARGET          fv3
                      LINKER_LANGUAGE ${FV3_LINKER_LANGUAGE}
                    )
 
+#GFortran-10 support
+if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    target_compile_options(fv3 PRIVATE -fallow-argument-mismatch)
+endif()
+
 ####################################################################################################
 # Install the Fortran modules
 ####################################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,7 +136,7 @@ ecbuild_add_library( TARGET          fv3
 
 #GFortran-10 support
 if(CMAKE_Fortran_COMPILER_ID MATCHES GNU AND CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-    target_compile_options(fv3 PRIVATE -fallow-argument-mismatch)
+    target_compile_options(fv3 PRIVATE -fallow-argument-mismatch -fallow-invalid-boz)
 endif()
 
 ####################################################################################################


### PR DESCRIPTION
Will require flags `-fallow-argument-mismatch` and  `-fallow-invalid-boz` for gfortran-10 support.

PS. @danholdaway something went wrong with setting the write permission for me on the JCSDA fork, so I'm issuing PR from a personal fork.