### PR TITLE
Make grid_spec.nc file path in namelist more generic

### DIFF
--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -629,7 +629,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
         grid_global => Atm%grid_global
-    else if( trim(grid_file) .NE. 'INPUT/grid_spec.nc') then
+    else if( trim(grid_file) .EQ. '') then
        allocate(grid_global(1-ng:npx  +ng,1-ng:npy  +ng,ndims,1:nregions))
     endif
     
@@ -683,7 +683,7 @@ contains
              ! still need to set up 
              call setup_aligned_nest(Atm)
           else
-           if(trim(grid_file) == 'INPUT/grid_spec.nc') then  
+           if(trim(grid_file) .NE. '') then  
              call read_grid(Atm, grid_file, ndims, nregions, ng)
            else
             if (Atm%flagstruct%grid_type>=0) call gnomonic_grids(Atm%flagstruct%grid_type, npx-1, xs, ys)
@@ -1181,7 +1181,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
     nullify(grid_global)
-    else if( trim(grid_file) .NE. 'INPUT/grid_spec.nc') then
+    else if( trim(grid_file) .EQ. '') then
        deallocate(grid_global)
     endif
 

--- a/tools/fv_grid_tools.F90
+++ b/tools/fv_grid_tools.F90
@@ -629,7 +629,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
         grid_global => Atm%grid_global
-    else if( trim(grid_file) .EQ. '') then
+    else if( trim(grid_file) .EQ. 'Inline') then
        allocate(grid_global(1-ng:npx  +ng,1-ng:npy  +ng,ndims,1:nregions))
     endif
     
@@ -683,7 +683,7 @@ contains
              ! still need to set up 
              call setup_aligned_nest(Atm)
           else
-           if(trim(grid_file) .NE. '') then  
+           if(trim(grid_file) .NE. 'Inline') then  
              call read_grid(Atm, grid_file, ndims, nregions, ng)
            else
             if (Atm%flagstruct%grid_type>=0) call gnomonic_grids(Atm%flagstruct%grid_type, npx-1, xs, ys)
@@ -1181,7 +1181,7 @@ contains
 
     if (Atm%neststruct%nested .or. ANY(Atm%neststruct%child_grids)) then
     nullify(grid_global)
-    else if( trim(grid_file) .EQ. '') then
+    else if( trim(grid_file) .EQ. 'Inline') then
        deallocate(grid_global)
     endif
 


### PR DESCRIPTION
The GFDL code has a namelist option to provide a "grid_spec" file which is useful for the regional applications as the grid doesn't have to be computed on the fly this way. However, the way the code is written, it has to be the file INPUT/grid_spec.nc, which means FV3-JEDI cannot regrid a regional grid to another regional grid. These if statements have been modified so that GFDL_atmos_cubed_sphere *should* work for any grid_spec file specified in the input.nml and not require it to be either none or INPUT/grid_spec.nc