### PR TITLE
add support for NVHPC compilers

### DIFF
--- a/cmake/fv3_compiler_flags.cmake
+++ b/cmake/fv3_compiler_flags.cmake
@@ -38,6 +38,10 @@ if (FV3_PRECISION MATCHES "DOUBLE" OR NOT FV3_PRECISION)
 
     set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8")
 
+  elseif( CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC" )
+
+    set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8")
+
   elseif( CMAKE_Fortran_COMPILER_ID MATCHES "XL" )
 
     set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qdpc")


### PR DESCRIPTION
## Description

NVIDIA recently acquired the compilers from PGI and changed the compiler id in cmake. I find this is necessary to get this repo to compile with the latest NVIDIA/PGI compiler suite, distributed within the NVIDIA HPC SDK 21.5.

## Definition of Done

JCSDA fv3-bundle compiles with NVIDIA HPC SDK 21.5
